### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-time-lwt.opam
+++ b/mirage-time-lwt.opam
@@ -19,7 +19,7 @@ doc: "https://mirage.github.io/mirage-time/"
 bug-reports: "https://github.com/mirage/mirage-time/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-time" {>= "1.0.0"}
   "lwt"
 ]

--- a/mirage-time-unix.opam
+++ b/mirage-time-unix.opam
@@ -19,7 +19,7 @@ doc: "https://mirage.github.io/mirage-time/"
 bug-reports: "https://github.com/mirage/mirage-time/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "lwt"
   "duration"

--- a/mirage-time.opam
+++ b/mirage-time.opam
@@ -19,7 +19,7 @@ doc: "https://mirage.github.io/mirage-time/"
 bug-reports: "https://github.com/mirage/mirage-time/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-device"
 ]
 build: [


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.